### PR TITLE
Move save and delete buttons both to right side

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -509,9 +509,10 @@ a:hover {
   vertical-align: middle;
 }
 .subtask-modal-summary {
+  box-sizing: border-box;
   height: 40px;
   line-height: 40px;
-  width: 90%;
+  width: 100%;
   border-radius: 3px;
   font-size: 24px;
   border-style: none;
@@ -528,7 +529,11 @@ a:hover {
   font-size: 20px;
   display: block;
   margin-top: 20px;
+  margin-left: 20px;
   cursor: pointer;
+}
+.clearfix {
+  clear: both;
 }
 .right {
   float: right;
@@ -563,6 +568,7 @@ a:hover {
   background-color: white;
   display: inline-block;
   width: 65%;
+  max-width: 900px;
   height: auto;
   z-index: 999;
   margin: 40px;

--- a/src/CreateEditSubTask.tsx
+++ b/src/CreateEditSubTask.tsx
@@ -160,8 +160,9 @@ class CreateSubTask extends React.Component<CreateSubTaskProps> {
           ) : (
             ""
           )}
+          <div className={"clearfix"} />
           <input
-            className={"subtask-modal-button background-blue" + (this.props.subtask ? " left" : "")}
+            className={"subtask-modal-button background-blue right"}
             type="submit"
             value="Save"
           />


### PR DESCRIPTION
Moves the save and delete buttons to the bottom right of Modal (and swaps them). Tightens up some of the padding as well to try make it not look so lopsided with the new button positions. But honestly it's not quite as good as I was hoping. I think in the future a modal sized based on content might work nicer?